### PR TITLE
Initialization of TutorialGeneralLicenses more flexible for mod compatibility

### DIFF
--- a/SteamStart/Main.cs
+++ b/SteamStart/Main.cs
@@ -27,11 +27,8 @@ public static class Main
 		var licenseManagerType = typeof(LicenseManager);
 		var licenseGeneralLicensesField = licenseManagerType.GetField("TutorialGeneralLicenses");
 		previousLIcenses = LicenseManager.TutorialGeneralLicenses;
-		licenseGeneralLicensesField.SetValue(null, new List<GeneralLicenseType_v2>
-			{
-				GeneralLicenseType.TrainDriver.ToV2(),
-				GeneralLicenseType.S060.ToV2()
-			});
+		LicenseManager.TutorialGeneralLicenses.RemoveAll(license => license.v1 == GeneralLicenseType.DE2);
+		LicenseManager.TutorialGeneralLicenses.Add(GeneralLicenseType.S060.ToV2());
 		GeneralLicenseType.DE2.ToV2().price = 20000f;
 	}
 	private static void UnpatchStartupLicensesAndItems()

--- a/SteamStart/Main.cs
+++ b/SteamStart/Main.cs
@@ -28,12 +28,14 @@ public static class Main
 		LicenseManager.TutorialGeneralLicenses.RemoveAll(license => license.v1 == GeneralLicenseType.DE2);
 		LicenseManager.TutorialGeneralLicenses.Add(GeneralLicenseType.S060.ToV2());
 		GeneralLicenseType.DE2.ToV2().price = 20000f;
+		GeneralLicenseType.S060.ToV2().price = 0f;
 	}
 	private static void UnpatchStartupLicensesAndItems()
 	{
-		var licenseManagerType = typeof(LicenseManager);
-		var licenseGeneralLicensesField = licenseManagerType.GetField("TutorialGeneralLicenses");
-		licenseGeneralLicensesField.SetValue(null, previousLIcenses);
+		LicenseManager.TutorialGeneralLicenses.RemoveAll(license => license.v1 == GeneralLicenseType.S060);
+		LicenseManager.TutorialGeneralLicenses.Add(GeneralLicenseType.DE2.ToV2());
+		GeneralLicenseType.S060.ToV2().price = 20000f;
+		GeneralLicenseType.DE2.ToV2().price = 0f;
 	}
 	static bool OnToggle(UnityModManager.ModEntry modEntry, bool value)
 	{

--- a/SteamStart/Main.cs
+++ b/SteamStart/Main.cs
@@ -24,8 +24,6 @@ public static class Main
 	}
 	private static void PatchStartupLicensesAndItems()
 	{
-		var licenseManagerType = typeof(LicenseManager);
-		var licenseGeneralLicensesField = licenseManagerType.GetField("TutorialGeneralLicenses");
 		previousLIcenses = LicenseManager.TutorialGeneralLicenses;
 		LicenseManager.TutorialGeneralLicenses.RemoveAll(license => license.v1 == GeneralLicenseType.DE2);
 		LicenseManager.TutorialGeneralLicenses.Add(GeneralLicenseType.S060.ToV2());

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
 	"Id": "SteamStart",
-	"Version": "1.2.0",
+	"Version": "1.2.1",
 	"DisplayName": "Steam Start",
 	"Author": "lassombra",
 	"EntryMethod": "SteamStart.Main.Load",


### PR DESCRIPTION
Changed the `.SetValue()` method to LINQ operators to update the existing made list inside LicenseManager.
This should allow for other mods to access the same list, regardless of load order